### PR TITLE
feat: support path to project command argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Using Node.js's npx command to run a one-off scan inside a project's directory:
 npx pie-my-vulns
 ```
 
+To scan a specific project directory use the `--directory` option, for example:
+
+```bash
+npx pie-my-vulns --directory=path/to/project/dir
+```
+
 # Install
 
 You can install globally via:

--- a/__tests__/__e2e__/cli.e2e.js
+++ b/__tests__/__e2e__/cli.e2e.js
@@ -66,4 +66,14 @@ describe('End-to-End CLI', () => {
     expect(err).toBe(undefined)
     expect(stdout).toContain('0 vulnerabilities found')
   })
+
+  test('CLI should accept path to project directory from command argument', async () => {
+    const project3Dir = path.join(__dirname, 'project3')
+    const { stdout, err } = await spawnAsync('node', [cliBinPath, `--directory=${project3Dir}`], {
+      cwd: path.join(__dirname, 'project1')
+    })
+
+    expect(err).toBe(undefined)
+    expect(stdout).toContain('0 vulnerabilities found')
+  })
 })

--- a/bin/pie-my-vulns.js
+++ b/bin/pie-my-vulns.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-process-exit */
 'use strict'
+const parseArgs = require('minimist')
 
 const Audit = require('../src/Audit')
 const SeverityReporter = require('../src/Reporters/SeverityReporter')
@@ -13,10 +14,12 @@ const EXIT_CODE_VULNS_NONE = 0
 const reportsList = [SeverityReporter, DependencyTypeReporter, RemediationTypeReporter]
 
 async function main() {
+  const argv = parseArgs(process.argv.slice(2))
+  const { directory } = argv
   let vulnerabilitiesResult
   const audit = new Audit()
   try {
-    vulnerabilitiesResult = await audit.test()
+    vulnerabilitiesResult = await audit.test({ directory })
   } catch (error) {
     printError(error)
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "cli-pie": "^2.4.1",
+    "minimist": "1.2.5",
     "snyk": "^1.295.0"
   },
   "devDependencies": {

--- a/src/Audit.js
+++ b/src/Audit.js
@@ -7,6 +7,7 @@ const ChildProcess = require('child_process')
 
 const nodeCliCommand = 'node'
 const auditCliCommand = path.join(__dirname, '../node_modules/snyk/dist/cli/index.js')
+const auditCliArgs = [auditCliCommand, 'test', '--json']
 const ERROR_VULNS_FOUND = 1
 const ERROR_UNAUTHENTICATED = 2
 const JSON_BUFFER_SIZE = 50 * 1024 * 1024
@@ -35,13 +36,13 @@ class Audit {
     })
   }
 
-  async test() {
+  async test({ directory = '' } = {}) {
     const ExecFile = Util.promisify(ChildProcess.execFile)
+    const args = [...auditCliArgs, ...(directory ? [directory] : [])]
     let testResults = []
-
     try {
       // allow for 50MB of buffer for a large JSON output
-      await ExecFile(nodeCliCommand, [auditCliCommand, 'test', '--json'], {
+      await ExecFile(nodeCliCommand, args, {
         maxBuffer: JSON_BUFFER_SIZE
       })
     } catch (error) {


### PR DESCRIPTION
Add support for a `--directory` option to scan a specific project.

<!--- Provide a general summary of your changes in the Title above -->

## Description

The CLI will now parse arguments, using the [`minimist`](https://www.npmjs.com/package/minimist) package (added, hope that's fine).

The `--directory` option value will be passed to the Audit `test` functionality (and through it to snyk command).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Resolves: #2 

## Motivation and Context

Allow the user to scan a specific project from another dir.

## How Has This Been Tested?

Locally and via the e2e (added test case).

## Screenshots (if appropriate):
<img width="851" alt="Screen Shot 2020-03-17 at 16 20 30" src="https://user-images.githubusercontent.com/6347577/76865397-55e3c000-686b-11ea-994d-e132e03b168f.png">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
