### PR TITLE
Add UTMs to monitor usage

### DIFF
--- a/__tests__/Audit.test.js
+++ b/__tests__/Audit.test.js
@@ -54,7 +54,9 @@ describe('Audit', () => {
     await audit.authenticate()
 
     expect(execFile).toHaveBeenCalled()
-    expect(execFile).toHaveBeenCalledWith('node', [expect.anything(), 'auth'])
+    expect(execFile).toHaveBeenCalledWith('node', [expect.anything(), 'auth'], {
+      env: expect.any(Object)
+    })
     expect(console.log.mock.calls).toEqual([
       [],
       ['or you can hit this link:'],

--- a/bin/pie-my-vulns.js
+++ b/bin/pie-my-vulns.js
@@ -3,6 +3,7 @@
 'use strict'
 const parseArgs = require('minimist')
 
+const debug = require('debug')('pie-my-vulns')
 const Audit = require('../src/Audit')
 const SeverityReporter = require('../src/Reporters/SeverityReporter')
 const RemediationTypeReporter = require('../src/Reporters/RemediationTypeReporter')
@@ -55,6 +56,7 @@ async function main() {
 function printError(error) {
   const githubIssueURL = 'https://github.com/lirantal/pie-my-vulns/issues'
 
+  debug(error)
   console.error()
   console.error(`Unexpected failure: ${error.message}`)
   console.error()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1276,9 +1276,9 @@
       }
     },
     "@snyk/cli-interface": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.3.0.tgz",
-      "integrity": "sha512-ecbylK5Ol2ySb/WbfPj0s0GuLQR+KWKFzUgVaoNHaSoN6371qRWwf2uVr+hPUP4gXqCai21Ug/RDArfOhlPwrQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.3.2.tgz",
+      "integrity": "sha512-jmZyxVHqzYU1GfdnWCGdd68WY/lAzpPVyqalHazPj4tFJehrSfEFc82RMTYAMgXEJuvFRFIwhsvXh3sWUhIQmg==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -1356,16 +1356,16 @@
       }
     },
     "@snyk/dep-graph": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.13.1.tgz",
-      "integrity": "sha512-Ww2xvm5UQgrq9eV0SdTBCh+w/4oI2rCx5vn1IOSeypaR0CO4p+do1vm3IDZ2ugg4jLSfHP8+LiD6ORESZMkQ2w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.16.1.tgz",
+      "integrity": "sha512-2RbstN/z5A3iTmgDQr0vfpWpqsjcJY54PXXP0gVXTf137QLdvgPEsZikjlofF4qoNO1io5t1VGvf69v9E8UrOw==",
       "requires": {
         "graphlib": "^2.1.5",
         "lodash": "^4.7.14",
         "object-hash": "^1.3.1",
         "semver": "^6.0.0",
         "source-map-support": "^0.5.11",
-        "tslib": "^1.9.3"
+        "tslib": "^1.10.0"
       }
     },
     "@snyk/gemfile": {
@@ -4057,9 +4057,9 @@
       }
     },
     "dockerfile-ast": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.18.tgz",
-      "integrity": "sha512-SEp95qCox1KAzf8BBtjHoBDD0a7/eNlZJ6fgDf9RxqeSEDwLuEN9YjdZ/tRlkrYLxXR4i+kqZzS4eDRSqs8VKQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.19.tgz",
+      "integrity": "sha512-iDRNFeAB2j4rh/Ecc2gh3fjciVifCMsszfCfHlYF5Wv8yybjZLiRDZUBt/pS3xrAz8uWT8fCHLq4pOQMmwCDwA==",
       "requires": {
         "vscode-languageserver-types": "^3.5.0"
       }
@@ -14614,13 +14614,13 @@
       }
     },
     "snyk": {
-      "version": "1.295.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.295.0.tgz",
-      "integrity": "sha512-4tRFx6c6kUAk55m5B86DlyENCS/0BIvRQhRj6C15PFKfsv+rh+dPTcYAujGCLch9WbWRI9OqOr+exUO/5YEPng==",
+      "version": "1.299.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.299.0.tgz",
+      "integrity": "sha512-K2dlmwlmJpD7CZE8B8GguwIJmjOWdXzQ7UlcFIscg8y0tP8OT9a1gouLgBaU4uyS5J5wByipGNX1Cpwi6WRt5w==",
       "requires": {
-        "@snyk/cli-interface": "2.3.0",
+        "@snyk/cli-interface": "2.3.2",
         "@snyk/configstore": "^3.2.0-rc1",
-        "@snyk/dep-graph": "1.13.1",
+        "@snyk/dep-graph": "1.16.1",
         "@snyk/gemfile": "1.2.0",
         "@snyk/snyk-cocoapods-plugin": "2.0.1",
         "@snyk/update-notifier": "^2.5.1-rc2",
@@ -14643,9 +14643,9 @@
         "proxy-from-env": "^1.0.0",
         "semver": "^6.0.0",
         "snyk-config": "^2.2.1",
-        "snyk-docker-plugin": "1.38.0",
+        "snyk-docker-plugin": "2.2.2",
         "snyk-go-plugin": "1.13.0",
-        "snyk-gradle-plugin": "3.2.4",
+        "snyk-gradle-plugin": "3.2.5",
         "snyk-module": "1.9.1",
         "snyk-mvn-plugin": "2.9.0",
         "snyk-nodejs-lockfile-parser": "1.17.0",
@@ -14829,12 +14829,12 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.38.0.tgz",
-      "integrity": "sha512-43HbJj6QatuL2BNG+Uq2Taa73wdfSQSID8FJWW4q5/LYgd9D+RtdiE4lAMwxqYYbvThU9uuza4epuF/B1CAlYw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-2.2.2.tgz",
+      "integrity": "sha512-ufeACGqtypUJ3AV5+bQw/mZLo40MC9tVHdRxpBw95w0F0Oa1MT5DATQj/K8RHpkEy8X6rlMmnxH8swyryFgRhg==",
       "requires": {
         "debug": "^4.1.1",
-        "dockerfile-ast": "0.0.18",
+        "dockerfile-ast": "0.0.19",
         "event-loop-spinner": "^1.1.0",
         "semver": "^6.1.0",
         "tar-stream": "^2.1.0",
@@ -14880,9 +14880,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.4.tgz",
-      "integrity": "sha512-XmS1gl7uZNHP9HP5RaPuRXW3VjkbdWe+EgSOlvmspztkubIOIainqc87k7rIJ6u3tLBhqsZK8b5ru0/E9Q69hQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.2.5.tgz",
+      "integrity": "sha512-XxPi/B16dGkV1USoyFbpn6LlSJ9SUC6Y6z/4lWuF4spLnKtWwpEb1bwTdBFsxnkUfqzIRtPr0+wcxxXvv9Rvcw==",
       "requires": {
         "@snyk/cli-interface": "2.3.0",
         "@types/debug": "^4.1.4",
@@ -14892,6 +14892,14 @@
         "tslib": "^1.9.3"
       },
       "dependencies": {
+        "@snyk/cli-interface": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.3.0.tgz",
+          "integrity": "sha512-ecbylK5Ol2ySb/WbfPj0s0GuLQR+KWKFzUgVaoNHaSoN6371qRWwf2uVr+hPUP4gXqCai21Ug/RDArfOhlPwrQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "cli-pie": "^2.4.1",
     "minimist": "1.2.2",
-    "snyk": "^1.295.0"
+    "snyk": "^1.299.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "cli-pie": "^2.4.1",
     "minimist": "1.2.2",
+    "debug": "^4.1.1",
     "snyk": "^1.299.0"
   },
   "devDependencies": {

--- a/src/Audit.js
+++ b/src/Audit.js
@@ -12,10 +12,18 @@ const ERROR_VULNS_FOUND = 1
 const ERROR_UNAUTHENTICATED = 2
 const JSON_BUFFER_SIZE = 50 * 1024 * 1024
 
+const shellEnvVariables = Object.assign({}, process.env, {
+  SNYK_UTM_MEDIUM: 'cli',
+  SNYK_UTM_SOURCE: 'cli',
+  SNYK_UTM_CAMPAIGN: 'pie-my-vulns'
+})
+
 class Audit {
   async authenticate() {
     return new Promise((resolve, reject) => {
-      const process = ChildProcess.execFile(nodeCliCommand, [auditCliCommand, 'auth'])
+      const process = ChildProcess.execFile(nodeCliCommand, [auditCliCommand, 'auth'], {
+        env: shellEnvVariables
+      })
       process.stdout.on('data', chunk => {
         const httpsLinkMatch = chunk.match(/https:\/\/.*/g)
         if (httpsLinkMatch && httpsLinkMatch.length > 0) {
@@ -43,7 +51,8 @@ class Audit {
     try {
       // allow for 50MB of buffer for a large JSON output
       await ExecFile(nodeCliCommand, args, {
-        maxBuffer: JSON_BUFFER_SIZE
+        maxBuffer: JSON_BUFFER_SIZE,
+        env: shellEnvVariables
       })
     } catch (error) {
       const errorMessage = error.stdout


### PR DESCRIPTION
## Description

This adds UTMs with the pie-my-vuln as a campaign so I can monitor the usage of snyk API calls when PMV invokes it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Updates tests to accommodate for the env vars passed into the spawned snyk process.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
