### PR TITLE
Issue 27 fix test command typo

### DIFF
--- a/__tests__/__e2e__/cli.e2e.js
+++ b/__tests__/__e2e__/cli.e2e.js
@@ -26,7 +26,7 @@ describe('End-to-End CLI', () => {
   })
 
   test('CLI should show vulnerabilities breakdown numbers and their titles', async () => {
-    expect.assertions(7)
+    expect.assertions(8)
 
     try {
       await spawnAsync('node', [cliBinPath], {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm yarn",
     "lint:fix": "eslint . --fix",
     "format": "prettier --config .prettierrc.js --write '**/*.js'",
-    "test": "jest -c jest.default.js && jest -c jest.default.js",
+    "test": "jest -c jest.default.js && jest -c jest.e2e.js",
     "test:e2e": "jest -c jest.e2e.js",
     "test:watch": "jest --watch",
     "coverage:view": "open-cli coverage/lcov-report/index.html",


### PR DESCRIPTION
Fix two typos preventing tests to run.

## Description

1. Typo in `package.json` , it was running `jest.default.js` twice instead of `jest.default.js` and `jest.e2e.js`

1. Typo in `End-to-End CLI` => `'CLI should show vulnerabilities breakdown numbers and their titles'` , was listed to expect 7 assertions while there are 8. 


## Related Issue
Fixes #27 

