### PR TITLE
fix: set cwd for failing testcase

### DIFF
--- a/__tests__/__e2e__/cli.e2e.js
+++ b/__tests__/__e2e__/cli.e2e.js
@@ -82,7 +82,9 @@ describe('End-to-End CLI', () => {
 
   test('CLI should be able to read Snyk JSON from stdin', async () => {
     try {
-      await exec(`cat snyk.json | node ${cliBinPath}`)
+      await exec(`cat snyk.json | node ${cliBinPath}`, {
+        cwd: __dirname
+      })
     } catch (err) {
       expect(err.status).toBe(2) // means that vulnerabilities were found
     }


### PR DESCRIPTION
## Description

This PR fixes a failing e2e test case due to wrong cwd.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#29 

## Motivation and Context

It makes all the e2e ✅

## How Has This Been Tested?

By running `npm run test:e2e`

## Screenshots (if appropriate):
<img width="577" alt="image" src="https://user-images.githubusercontent.com/37476886/94731317-32551280-0382-11eb-827d-2f89d94dd29b.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
