### PR TITLE
fix: run pipe from stdin test only on linux

### DIFF
--- a/__tests__/__e2e__/cli.e2e.js
+++ b/__tests__/__e2e__/cli.e2e.js
@@ -80,13 +80,15 @@ describe('End-to-End CLI', () => {
     expect(stdout).toContain('0 vulnerabilities found')
   })
 
-  test('CLI should be able to read Snyk JSON from stdin', async () => {
-    try {
-      await exec(`cat snyk.json | node ${cliBinPath}`, {
-        cwd: __dirname
-      })
-    } catch (err) {
-      expect(err.status).toBe(2) // means that vulnerabilities were found
-    }
-  })
+  if (os.platform() === 'linux') {
+    test('CLI should be able to read Snyk JSON from stdin', async () => {
+      try {
+        await exec(`cat snyk.json | node ${cliBinPath}`, {
+          cwd: __dirname
+        })
+      } catch (err) {
+        expect(err.status).toBe(2) // means that vulnerabilities were found
+      }
+    })
+  }
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes the testcase for piping Snyk JSON from stdin run only on linux OS.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Related to #5 , https://github.com/lirantal/pie-my-vulns/pull/73#issuecomment-702356949

## Motivation and Context

It prevents the testcase from running on Windows, which causes the CI to fail.

## How Has This Been Tested?

`npm run test:e2e` on macOS and the test doesn't run.

## Screenshots (if appropriate):

<img width="578" alt="image" src="https://user-images.githubusercontent.com/37476886/94901887-f79fc700-04b4-11eb-8e12-bdf3bfac01f7.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
